### PR TITLE
DP-86: Cloudfront 502 configuration tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,7 @@ deploy:
 	--parameters DBSnapshotIdentifier=arn:aws:rds:us-east-1:992593896645:cluster-snapshot:oe-patterns-drupal-default-20200519 \
 	--parameters ElastiCacheEnable=true \
 	--parameters PipelineArtifactBucketName=github-user-and-bucket-taskcatbucket-2zppaw3wi3sx \
-	--parameters SecretArn=arn:aws:secretsmanager:us-east-1:992593896645:secret:/test/drupal/secret-P6y46J \
-	--parameters PipelineArtifactBucketName=github-user-and-bucket-taskcatbucket-2zppaw3wi3sx
+	--parameters SecretArn=arn:aws:secretsmanager:us-east-1:992593896645:secret:/test/drupal/secret-P6y46J
 
 destroy:
 	docker-compose run -w /code/cdk --rm drupal cdk destroy

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ deploy:
 	--parameters DBSnapshotIdentifier=arn:aws:rds:us-east-1:992593896645:cluster-snapshot:oe-patterns-drupal-default-20200519 \
 	--parameters ElastiCacheEnable=true \
 	--parameters PipelineArtifactBucketName=github-user-and-bucket-taskcatbucket-2zppaw3wi3sx \
-	--parameters SecretArn=arn:aws:secretsmanager:us-east-1:992593896645:secret:/test/drupal/secret-P6y46J
+	--parameters SecretArn=arn:aws:secretsmanager:us-east-1:992593896645:secret:/test/drupal/secret-P6y46J \
+	--parameters SourceArtifactS3ObjectKey=aws-marketplace-oe-patterns-drupal-example-site/refs/heads/develop.tar.gz
 
 destroy:
 	docker-compose run -w /code/cdk --rm drupal cdk destroy

--- a/cdk/drupal/drupal_stack.py
+++ b/cdk/drupal/drupal_stack.py
@@ -1406,14 +1406,15 @@ class DrupalStack(core.Stack):
             "CloudFrontDistribution",
             distribution_config=aws_cloudfront.CfnDistribution.DistributionConfigProperty(
                 # TODO: parameterize or integrate alias with Route53; also requires a valid certificate
-                aliases=[ "{}.dev.patterns.ordinaryexperts.com".format(core.Aws.STACK_NAME) ],
+                aliases=[ "cdn-{}.dev.patterns.ordinaryexperts.com".format(core.Aws.STACK_NAME) ],
                 comment=core.Aws.STACK_NAME,
                 default_cache_behavior=aws_cloudfront.CfnDistribution.DefaultCacheBehaviorProperty(
                     allowed_methods=[ "HEAD", "GET" ],
                     compress=False,
                     default_ttl=86400,
                     forwarded_values=aws_cloudfront.CfnDistribution.ForwardedValuesProperty(
-                        query_string=False
+                        headers=[ "Host" ],
+                        query_string=True
                     ),
                     min_ttl=0,
                     max_ttl=31536000,
@@ -1425,7 +1426,8 @@ class DrupalStack(core.Stack):
                     domain_name=alb.attr_dns_name,
                     id="alb",
                     custom_origin_config=aws_cloudfront.CfnDistribution.CustomOriginConfigProperty(
-                        origin_protocol_policy=cloudfront_origin_access_policy_param.value_as_string
+                        origin_protocol_policy=cloudfront_origin_access_policy_param.value_as_string,
+                        origin_ssl_protocols=[ "TLSv1.2" ]
                     )
                 )],
                 price_class=cloudfront_price_class_param.value_as_string,
@@ -1435,6 +1437,7 @@ class DrupalStack(core.Stack):
                         cloudfront_certificate_arn_param.value_as_string,
                         core.Aws.NO_VALUE
                     ).to_string(),
+                    minimum_protocol_version="TLSv1.2_2018",
                     ssl_support_method=core.Fn.condition_if(
                         cloudfront_certificate_arn_exists_condition.logical_id,
                         "sni-only",


### PR DESCRIPTION
Defined the minimum TLS requirements for communication with origin. Forwarding querystring and headers (except Host). Prepping a cdn-* alias for certificate verification.

Caution: This branch contains PR #25 with DP-42 changes, so that should be merged first.