### PR TITLE
DP-64: CloudFront CodePipeline invalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Add deployment guide
 * Parameter name consistency
 * make gen-plf - generates Product Load Form info
+* CloudFront cache invalidation
 
 # 0.3.0
 

--- a/cdk/drupal/cloudfront_invalidation_lambda_function_code.py
+++ b/cdk/drupal/cloudfront_invalidation_lambda_function_code.py
@@ -1,0 +1,49 @@
+import os
+import logging
+
+from datetime import datetime
+
+import boto3
+import botocore
+
+logger = logging.getLogger()
+logger.setLevel('INFO')
+
+cloudfront_client = boto3.client("cloudfront")
+codepipeline_client = boto3.client("codepipeline")
+
+def lambda_handler(event, context):
+    job_id = event["CodePipeline.job"]["id"]
+    logger.info("CloudFront Invalidation Lambda starting with job id: {}...".format(job_id))
+
+    now = datetime.now()
+    now_formatted = now.strftime("%Y%m%dT%H%m%S")
+    
+    try:
+        logger.info("Creating CloudFront Invalidation: {}...".format(now_formatted))
+        cloudfront_client.create_invalidation(
+            DistributionId=os.environ["CloudFrontDistributionId"],
+            InvalidationBatch={
+                "Paths": {
+                    "Quantity": 1,
+                    "Items": [
+                        "/*"
+                    ]
+                },
+                "CallerReference": now_formatted
+            }
+        )
+        logger.info("Created")
+
+        codepipeline_client.put_job_success_result(jobId=job_id)
+    except Exception as e:
+        logger.error("Failed")
+        logger.error(e)
+        codepipeline_client.put_job_failure_result(
+            failureDetails={
+                "type": "JobFailed",
+                "message": str(e)
+            },
+            jobId=job_id
+        )
+    

--- a/cdk/drupal/drupal_stack.py
+++ b/cdk/drupal/drupal_stack.py
@@ -1866,7 +1866,7 @@ class DrupalStack(core.Stack):
                 )
             ]
         )
-        # TODO: open issue
+        # https://github.com/aws/aws-cdk/issues/8396
         codepipeline.add_override(
             "Properties.Stages.3",
             {

--- a/cdk/drupal/drupal_stack.py
+++ b/cdk/drupal/drupal_stack.py
@@ -1879,7 +1879,7 @@ class DrupalStack(core.Stack):
                                     "Category": "Invoke",
                                     "Owner": "AWS",
                                     "Provider": "Lambda",
-                                    "Version": 1
+                                    "Version": "1"
                                 },
                                 "Configuration": {
                                     "FunctionName": cloudfront_invalidation_lambda_function.ref

--- a/cdk/setup.py
+++ b/cdk/setup.py
@@ -5,7 +5,7 @@ with open("README.md") as fp:
     long_description = fp.read()
 
 
-CDK_VERSION="1.36.1"
+CDK_VERSION="1.42.1"
 
 setuptools.setup(
     name="drupal",

--- a/cdk/setup.py
+++ b/cdk/setup.py
@@ -33,6 +33,7 @@ setuptools.setup(
         f"aws-cdk.aws-elasticache=={CDK_VERSION}",
         f"aws-cdk.aws-elasticloadbalancingv2=={CDK_VERSION}",
         f"aws-cdk.aws-iam=={CDK_VERSION}",
+        f"aws-cdk.aws-lambda=={CDK_VERSION}",
         f"aws-cdk.aws-rds=={CDK_VERSION}",
         f"aws-cdk.aws-s3=={CDK_VERSION}",
         f"aws-cdk.aws-secretsmanager=={CDK_VERSION}",

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -2,7 +2,7 @@
 
 echo "$(date): Starting setup-env.sh"
 
-export CDK_VERSION=1.36.1
+export CDK_VERSION=1.42.1
 export PACKER_VERSION=1.5.5
 export TASKCAT_VERSION=0.9.18
 


### PR DESCRIPTION
Adds a new deployment stage, action and lambda for creating a CloudFront cache invalidation after deploy.

Also includes some variable renaming to add namespaces by aws services.