### PR TITLE
SourceArtifactBucketName Output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Switching to common VPC construct from OE CDK repo
 * Upgrade CDK to 1.57.0
 * Reorganizing DrupalStack class code
+* Adding output for SourceArtifactBucketName
 
 # 1.0.0
 

--- a/cdk/drupal/drupal_stack.py
+++ b/cdk/drupal/drupal_stack.py
@@ -1879,6 +1879,11 @@ class DrupalStack(core.Stack):
             value="{}:{}".format(elasticache_cluster.attr_configuration_endpoint_address,
                                  elasticache_cluster.attr_configuration_endpoint_port)
         )
+        source_artifact_bucket_name_output = core.CfnOutput(
+            self,
+            "SourceArtifactBucketNameOutput",
+            value=source_artifact_bucket_name
+        )
         
         # AWS::CloudFormation::Interface
         self.template_options.metadata = {


### PR DESCRIPTION
After running the stack as a new customer, one of the first logical things to do is try to find the SourceArtifactBucket to push a deploy zip -- we should add this value as a stack output to make it easy to find.