### PR TITLE
PAT-133: Unique notification topic name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Switching to common VPC construct from OE CDK repo
 * Upgrade CDK to 1.57.0
 * Reorganizing DrupalStack class code
+* Adding uuid to notification topic name
 
 # 1.0.0
 

--- a/cdk/drupal/drupal_stack.py
+++ b/cdk/drupal/drupal_stack.py
@@ -713,7 +713,7 @@ class DrupalStack(core.Stack):
         notification_topic = aws_sns.CfnTopic(
             self,
             "NotificationTopic",
-            topic_name="{}-notifications".format(core.Aws.STACK_NAME)
+            topic_name=append_stack_uuid(f"{core.Aws.STACK_NAME}-notifications")
         )
         notification_subscription = aws_sns.CfnSubscription(
             self,


### PR DESCRIPTION
I ran into a strange issue. I was destroying a stack that failed, while trying to bring a new one up simultaneously. The new one failed because there was an existing notification topic by the same name. I imagine we might run into more of these issues, but shouldn't hurt to make this unique per stack.