### PR TITLE
Forward SSESS* cookie; increase RDS max_allowed_packet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 
 * Fixing taskcat tests
+* CloudFront: forward Drupal https session cookie to origin
+* Increase RDS max_allowed_packet parameter to prevent error during MySQL dump imports
 
 # 2.0.0
 

--- a/cdk/drupal/drupal_stack.py
+++ b/cdk/drupal/drupal_stack.py
@@ -716,7 +716,7 @@ class DrupalStack(Stack):
                     forwarded_values=aws_cloudfront.CfnDistribution.ForwardedValuesProperty(
                         cookies=aws_cloudfront.CfnDistribution.CookiesProperty(
                             forward="whitelist",
-                            whitelisted_names=[ "SESS*" ]
+                            whitelisted_names=[ "SESS*", "SSESS*" ]
                         ),
                         headers=[
                             "CloudFront-Forwarded-Proto",

--- a/cdk/drupal/drupal_stack.py
+++ b/cdk/drupal/drupal_stack.py
@@ -490,7 +490,8 @@ class DrupalStack(Stack):
                 "log_output": "FILE",
                 "log_queries_not_using_indexes": "1",
                 "long_query_time": "10",
-                "slow_query_log": "1"
+                "slow_query_log": "1",
+                "max_allowed_packet": "1073741824"
             }
         )
         secret = aws_secretsmanager.CfnSecret(


### PR DESCRIPTION
## Forward SSESS* cookie
Drupal has different session cookie prefixes for http and https protocols. The SSESS* cookie is used for https. Since CloudFront can connect to the origin (ALB) over https, the SSESS* cookie needs to be forwarded, otherwise a user cannot log in.

https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Session%21SessionConfiguration.php/function/SessionConfiguration%3A%3AgetName/10

## Increase RDS max_allowed_packet
Increase RDS max_allowed_packet parameter to prevent error during MySQL dump imports

- The default value is too small for some database imports, resulting in:

  > "Error in query (1153): Got a packet bigger than 'max_allowed_packet' bytes".

This is addressed by increasing the value.


BTW, Happy New Year and hope this is useful for this fantastic Drupal CDK stack. 