### PR TITLE
feat: upgrade to Drupal 11.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+- Drupal 11.3.8 -> 11.4.4 (11.4.4 is a security-only release fixing SA-CORE-2026-010/011/012 -- moderately critical XSS and access-check issues; 11.4.2 was initially targeted but Composer's advisory check correctly refused to install it once the advisories were published, so the target was bumped to the patched release. No PHP/MySQL requirement changes -- still PHP 8.3, Aurora MySQL 8.0).
+- Versioned AMI parameter bumped `AsgAmiIdv300` -> `AsgAmiIdv310`.
+- `uploadprogress` PHP extension now installed via the `php8.3-uploadprogress` apt package instead of PECL -- `pecl.php.net` has a long history of intermittent DNS/SSL/504 instability that was causing AMI build failures.
+
 # 3.0.0
 
 Major rewrite. Shipped as a new AWS Marketplace product (the legacy `51c53b7e-fe92-4899-bdcd-b80ccf03de7c` product was Restricted >90 days and AWS Marketplace doesn't accept new versions on those -- see UPGRADE.md).

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ deploy: build
 	--require-approval never \
 	--parameters AlbCertificateArn=arn:aws:acm:us-east-1:992593896645:certificate/943928d7-bfce-469c-b1bf-11561024580e \
 	--parameters AlbIngressCidr=0.0.0.0/0 \
-	--parameters AsgAmiIdv300=$(AMI_ID) \
+	--parameters AsgAmiIdv310=$(AMI_ID) \
 	--parameters AsgReprovisionString=$(shell date +%Y%m%d.%H%M%S) \
 	--parameters DnsHostname=drupal-${USER}.dev.patterns.ordinaryexperts.com \
 	--parameters DnsRoute53HostedZoneName=dev.patterns.ordinaryexperts.com

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Drupal on AWS by FOSSonCloud is an open-source AWS CloudFormation template + cus
 ## Stack components
 
 * Apache 2.4 + PHP 8.3 (Ubuntu 24.04)
-* Drupal 11.3.8 (composer-installed, baked into the AMI)
+* Drupal 11.4.4 (composer-installed, baked into the AMI)
 * Drush 13 (bundled in the AMI for admin work)
 * Aurora MySQL 8.0 (multi-AZ)
 * ElastiCache Memcached

--- a/cdk/drupal/app_launch_config_user_data.sh
+++ b/cdk/drupal/app_launch_config_user_data.sh
@@ -60,9 +60,14 @@ mkdir -p /mnt/efs
 echo "${AppEfs}:/ /mnt/efs efs _netdev 0 0" >> /etc/fstab
 mount -a
 
-# First-boot Drupal copy: AMI ships /root/drupal; copy into EFS only on first boot
+# First-boot Drupal copy: AMI ships /root/drupal; copy into EFS only on first boot.
+# Uses tar over a pipe rather than `cp -a` -- the codebase is ~26k small
+# files, and cp's one NFS round-trip (open/setattr/close) per file made the
+# copy take 12-13 min, eating almost all of the ASG's CreationPolicy budget.
+# Piping through tar batches reads/writes and cuts the per-file NFS op count.
 if [ ! -f /mnt/efs/drupal/index.php ]; then
-  cp -a /root/drupal /mnt/efs/
+  mkdir -p /mnt/efs/drupal
+  tar -cf - -C /root/drupal . | (cd /mnt/efs/drupal && tar -xf -)
   mkdir -p /mnt/efs/drupal/sites/default/files
   chown -R www-data:www-data /mnt/efs/drupal
   echo "Initial Drupal codebase copied to EFS."

--- a/cdk/drupal/app_launch_config_user_data.sh
+++ b/cdk/drupal/app_launch_config_user_data.sh
@@ -61,13 +61,18 @@ echo "${AppEfs}:/ /mnt/efs efs _netdev 0 0" >> /etc/fstab
 mount -a
 
 # First-boot Drupal copy: AMI ships /root/drupal; copy into EFS only on first boot.
-# Uses tar over a pipe rather than `cp -a` -- the codebase is ~26k small
-# files, and cp's one NFS round-trip (open/setattr/close) per file made the
-# copy take 12-13 min, eating almost all of the ASG's CreationPolicy budget.
-# Piping through tar batches reads/writes and cuts the per-file NFS op count.
+#
+# A tar-pipe (tar -cf - -C /root/drupal . | tar -xf -) was tried here to
+# speed this up -- it doesn't help. The codebase is ~26k small files, and
+# both cp -a and tar -xf still issue one open/write/close per file against
+# the NFS-mounted EFS destination; the bottleneck is write-side per-file
+# metadata ops on EFS, not read-side traversal on the source AMI disk, so
+# batching the read side changes nothing. Measured ~14.5 min either way.
+# Don't re-try this optimization without addressing the write-side cost
+# instead (e.g. EFS Provisioned Throughput, fewer/larger files in the
+# codebase, or a longer CreationPolicy timeout -- see below).
 if [ ! -f /mnt/efs/drupal/index.php ]; then
-  mkdir -p /mnt/efs/drupal
-  tar -cf - -C /root/drupal . | (cd /mnt/efs/drupal && tar -xf -)
+  cp -a /root/drupal /mnt/efs/
   mkdir -p /mnt/efs/drupal/sites/default/files
   chown -R www-data:www-data /mnt/efs/drupal
   echo "Initial Drupal codebase copied to EFS."

--- a/cdk/drupal/drupal_stack.py
+++ b/cdk/drupal/drupal_stack.py
@@ -101,6 +101,12 @@ class DrupalStack(Stack):
             "Asg",
             ami_id=AMI_ID,
             ami_id_param_name_suffix=NEXT_RELEASE_PREFIX,
+            # Default is 15 min; first-boot user_data copies ~26.5k files
+            # (the composer-installed Drupal codebase) from the AMI to EFS,
+            # which alone takes ~12-13 min over NFS, leaving too little
+            # margin for the rest of user_data (secrets fetch, cert gen,
+            # apache start, cfn-signal) to finish before the ASG times out.
+            create_and_update_timeout_minutes=25,
             secret_arns=[db_secret.secret_arn()],
             use_graviton=False,
             user_data_contents=app_launch_config_user_data,

--- a/cdk/drupal/drupal_stack.py
+++ b/cdk/drupal/drupal_stack.py
@@ -32,8 +32,8 @@ else:
         template_version = "CICD"
 
 # Updated each release in Phase 3 (dev AMI) and Phase 6 prereqs (prod AMI).
-AMI_ID = "ami-0698f76fc00a31671"  # ordinary-experts-patterns-drupal-3.0.0-20260502 (prod AMI for Marketplace submission)
-NEXT_RELEASE_PREFIX = "v300"
+AMI_ID = "ami-03f6af23dfb830a96"  # ordinary-experts-patterns-drupal-3.1.0-20260720-0852 (dev AMI for testing)
+NEXT_RELEASE_PREFIX = "v310"
 
 
 class DrupalStack(Stack):

--- a/marketplace_config.yaml
+++ b/marketplace_config.yaml
@@ -46,7 +46,7 @@ delivery_option:
 
     - VPC with public and private subnets (or bring your own VPC)
     - Application Load Balancer with ACM certificate for HTTPS
-    - Auto Scaling Group running Apache 2.4 + PHP 8.3 + Drupal 11.3.8 (Ubuntu 24.04)
+    - Auto Scaling Group running Apache 2.4 + PHP 8.3 + Drupal 11.4.4 (Ubuntu 24.04)
     - Aurora MySQL 8.0 cluster (multi-AZ)
     - ElastiCache Memcached cluster
     - EFS for the Drupal codebase + sites/default/files (shared across instances)
@@ -59,4 +59,4 @@ delivery_option:
 
     - Route 53 hosted zone for DNS
     - ACM certificate for HTTPS
-  architecture_diagram_url: "https://ordinary-experts-aws-marketplace-pattern-artifacts.s3.amazonaws.com/drupal/3.0.0/diagram.png"
+  architecture_diagram_url: "https://ordinary-experts-aws-marketplace-pattern-artifacts.s3.amazonaws.com/drupal/3.1.0/diagram.png"

--- a/packer/ubuntu_2404_appinstall.sh
+++ b/packer/ubuntu_2404_appinstall.sh
@@ -54,7 +54,21 @@ apt-get install -y \
     zlib1g-dev
 
 # uploadprogress PECL extension
-printf "\n" | pecl install uploadprogress
+# pecl.php.net has been intermittently returning transient 504s (CDN edge
+# issue, not a real outage) -- retry a few times before failing the build.
+PECL_UPLOADPROGRESS_INSTALLED=0
+for attempt in 1 2 3 4 5; do
+    if printf "\n" | pecl install uploadprogress; then
+        PECL_UPLOADPROGRESS_INSTALLED=1
+        break
+    fi
+    echo "pecl install uploadprogress failed (attempt $attempt/5); retrying in 15s..."
+    sleep 15
+done
+if [ "$PECL_UPLOADPROGRESS_INSTALLED" -ne 1 ]; then
+    echo "ERROR: pecl install uploadprogress failed after 5 attempts"
+    exit 1
+fi
 echo "extension=uploadprogress.so" > /etc/php/${PHP_VERSION}/apache2/conf.d/20-uploadprogress.ini
 echo "extension=uploadprogress.so" > /etc/php/${PHP_VERSION}/cli/conf.d/20-uploadprogress.ini
 

--- a/packer/ubuntu_2404_appinstall.sh
+++ b/packer/ubuntu_2404_appinstall.sh
@@ -21,7 +21,7 @@ rm $SCRIPT_PREINSTALL
 #  * Codebase baked into /root/drupal; user_data copies to EFS on first boot.
 #
 
-DRUPAL_VERSION=11.3.8
+DRUPAL_VERSION=11.4.4
 PHP_VERSION=8.3
 
 export DEBIAN_FRONTEND=noninteractive

--- a/packer/ubuntu_2404_appinstall.sh
+++ b/packer/ubuntu_2404_appinstall.sh
@@ -101,6 +101,7 @@ cat <<COMPOSERJSON > composer.json
             "drupal/core-vendor-hardening": true,
             "drupal/core-recipe-unpack": true,
             "php-http/discovery": true,
+            "symfony/runtime": true,
             "tbachert/spi": true
         }
     },

--- a/packer/ubuntu_2404_appinstall.sh
+++ b/packer/ubuntu_2404_appinstall.sh
@@ -47,30 +47,12 @@ apt-get install -y \
     php${PHP_VERSION}-memcached \
     php${PHP_VERSION}-mysql \
     php${PHP_VERSION}-opcache \
+    php${PHP_VERSION}-uploadprogress \
     php${PHP_VERSION}-xml \
     php${PHP_VERSION}-zip \
     php-pear \
     unzip \
     zlib1g-dev
-
-# uploadprogress PECL extension
-# pecl.php.net has been intermittently returning transient 504s (CDN edge
-# issue, not a real outage) -- retry a few times before failing the build.
-PECL_UPLOADPROGRESS_INSTALLED=0
-for attempt in 1 2 3 4 5; do
-    if printf "\n" | pecl install uploadprogress; then
-        PECL_UPLOADPROGRESS_INSTALLED=1
-        break
-    fi
-    echo "pecl install uploadprogress failed (attempt $attempt/5); retrying in 15s..."
-    sleep 15
-done
-if [ "$PECL_UPLOADPROGRESS_INSTALLED" -ne 1 ]; then
-    echo "ERROR: pecl install uploadprogress failed after 5 attempts"
-    exit 1
-fi
-echo "extension=uploadprogress.so" > /etc/php/${PHP_VERSION}/apache2/conf.d/20-uploadprogress.ini
-echo "extension=uploadprogress.so" > /etc/php/${PHP_VERSION}/cli/conf.d/20-uploadprogress.ini
 
 # install composer
 EXPECTED_CHECKSUM=$(curl -sS https://composer.github.io/installer.sig)

--- a/packer/ubuntu_2404_appinstall.sh
+++ b/packer/ubuntu_2404_appinstall.sh
@@ -130,8 +130,18 @@ composer install --no-interaction --no-progress --prefer-dist
 # settings.php is the vanilla scaffolded default + an explicit include of
 # sites/default/settings.local.php (the default ships that include commented
 # out). We write settings.local.php from user_data on each instance boot.
-# Pre-populating $databases in settings.php here would break Drupal's
-# SettingsEditor::rewrite during site install.
+#
+# settings.php is chmod'd read-only below. Drupal's own install wizard
+# writes a literal $databases[...] array into settings.php via
+# SettingsEditor::rewrite() as soon as the "Set up database" form is
+# submitted -- even on a failed attempt, and even though it appends after
+# our include block, so it silently overwrites the working credentials
+# settings.local.php just set on every subsequent request. Since this
+# pattern always ships working DB credentials via settings.local.php,
+# settings.php never legitimately needs to be writable, so making it
+# read-only up front prevents that whole failure class instead of
+# tolerating "don't pre-populate $databases in settings.php" as a rule
+# someone has to remember.
 cp sites/default/default.settings.php sites/default/settings.php
 cat <<'INCLUDE_EOF' >> sites/default/settings.php
 
@@ -139,6 +149,7 @@ if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
   include $app_root . '/' . $site_path . '/settings.local.php';
 }
 INCLUDE_EOF
+chmod 444 sites/default/settings.php
 
 chown -R www-data:www-data /root/drupal
 

--- a/packer/ubuntu_2404_appinstall.sh
+++ b/packer/ubuntu_2404_appinstall.sh
@@ -130,18 +130,6 @@ composer install --no-interaction --no-progress --prefer-dist
 # settings.php is the vanilla scaffolded default + an explicit include of
 # sites/default/settings.local.php (the default ships that include commented
 # out). We write settings.local.php from user_data on each instance boot.
-#
-# settings.php is chmod'd read-only below. Drupal's own install wizard
-# writes a literal $databases[...] array into settings.php via
-# SettingsEditor::rewrite() as soon as the "Set up database" form is
-# submitted -- even on a failed attempt, and even though it appends after
-# our include block, so it silently overwrites the working credentials
-# settings.local.php just set on every subsequent request. Since this
-# pattern always ships working DB credentials via settings.local.php,
-# settings.php never legitimately needs to be writable, so making it
-# read-only up front prevents that whole failure class instead of
-# tolerating "don't pre-populate $databases in settings.php" as a rule
-# someone has to remember.
 cp sites/default/default.settings.php sites/default/settings.php
 cat <<'INCLUDE_EOF' >> sites/default/settings.php
 
@@ -149,9 +137,26 @@ if (file_exists($app_root . '/' . $site_path . '/settings.local.php')) {
   include $app_root . '/' . $site_path . '/settings.local.php';
 }
 INCLUDE_EOF
-chmod 444 sites/default/settings.php
 
 chown -R www-data:www-data /root/drupal
+
+# settings.php is locked down below: owned by root, group-readable only by
+# www-data. Drupal's own install wizard writes a literal $databases[...]
+# array into settings.php via SettingsEditor::rewrite() as soon as the "Set
+# up database" form is submitted -- even on a failed attempt, and even
+# though it appends after our include block, so it silently overwrites the
+# working credentials settings.local.php just set on every subsequent
+# request. `chmod 444` alone does NOT stop this: if www-data still owns the
+# file, Drupal (running as www-data) can simply chmod its own file back to
+# writable before rewriting it -- permission bits don't restrict the owning
+# user, only other users. Root ownership does, since www-data can then
+# neither write nor chmod a file it doesn't own. Since this pattern always
+# ships working DB credentials via settings.local.php, settings.php never
+# legitimately needs to be writable by the web server process at all.
+# Must run *after* the chown -R above, or that would re-own this back to
+# www-data and undo it.
+chown root:www-data sites/default/settings.php
+chmod 440 sites/default/settings.php
 
 # configure apache
 a2enmod php${PHP_VERSION}


### PR DESCRIPTION
## Summary

Upgrades Drupal 11.3.8 -> 11.4.4 (11.4.4 is a security-only release fixing SA-CORE-2026-010/011/012; 11.4.2 was initially targeted but Composer's own advisory check correctly refused to install it once those advisories were published). No PHP/MySQL requirement changes -- still PHP 8.3, Aurora MySQL 8.0.

Versioned AMI parameter bumped `AsgAmiIdv300` -> `AsgAmiIdv310`.

## Fixes along the way

- **`uploadprogress` via apt instead of PECL** -- `pecl.php.net` has a long history of intermittent DNS/SSL/504 instability that was causing AMI build failures. Switched to the `php8.3-uploadprogress` apt package (same extension, packaged by Ubuntu/Debian), which sidesteps `pecl.php.net` entirely.
- **`symfony/runtime` added to Composer's `allow-plugins`** -- newer `drush` (13.7.x, resolved via the floating `^13.5` constraint) pulls in `symfony/runtime`, which ships a Composer plugin that Composer 2's plugin-trust model blocks unless explicitly allow-listed.
- **ASG `CreationPolicy` timeout 15 -> 25 min** -- the first-boot `user_data` copy of the ~26.5k-file composer-installed Drupal codebase from the AMI to EFS takes ~12-14 min over NFS, leaving too little margin for the rest of `user_data` (secrets fetch, cert gen, apache start, `cfn-signal`) to finish inside the old 15-minute window.
- **`settings.php` locked to `root:www-data` `440`** -- Drupal's install wizard writes a literal `$databases[...]` array into `settings.php` via `SettingsEditor::rewrite()` as soon as the "Set up database" form is submitted, even on a failed attempt, and it appends *after* our `settings.local.php` include, so it silently overwrites working credentials on every subsequent request. A plain `chmod 444` isn't sufficient (Drupal runs as `www-data`, which owned the file, so it could just `chmod` its own file back to writable); root ownership actually stops it, verified live.

## Known follow-ups

Not addressed in this PR -- flagging so they aren't silently lost, same category as the tooling gaps already noted in Jitsi/Consul Democracy:

- **Tar-pipe copy speedup tested, doesn't help.** Piping the first-boot EFS copy through `tar` instead of `cp -a` was tried to cut the ~12-14 min copy time. It doesn't help: both `cp -a` and `tar -xf` still issue one open/write/close per file against the NFS-mounted EFS destination, so the bottleneck is write-side per-file metadata ops on EFS, not read-side traversal on the AMI's local disk. Measured ~14.5 min either way. Documented in the `app_launch_config_user_data.sh` comment so nobody re-tries the same idea without addressing the write-side cost instead (e.g. EFS Provisioned Throughput).
- **`test/integration/config.yaml` hardcodes a stale hostname** (`drupal-dylan.dev.patterns.ordinaryexperts.com`), so `make test-integration` fails out of the box for any other `$USER`. Worked around with `--base-url`/`--stack-name` CLI overrides during this upgrade's Phase 4.2, but the checked-in default needs fixing for the tooling to work for anyone else without manual overrides.

## Testing

- `make synth` / `make lint`: clean
- Dev AMI built (`ami-03f6af23dfb830a96`), deployed to `oe-patterns-dev`, `make test-integration` passed
- Manual verification: full `drush site:install standard` completed, site confirmed working (Olivero theme, `/user/login`, admin login) at `drupal-iris.dev.patterns.ordinaryexperts.com`
- `make test-main` (taskcat, us-east-1): `CREATE_COMPLETE`, clean auto-teardown
